### PR TITLE
fix: typo in `page.js`

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,5 @@
 import { SubscriptionForm } from "@/components/subscription-form";
-import { Subscribers } from "@/components/Subscribers";
+import { Subscribers } from "@/components/subscribers";
 
 export default function Home() {
   return (


### PR DESCRIPTION
This was blocking me from running the project on linux.
```bash
> pnpm dev

> nextjs-email@0.1.0 dev /projects/nextjs-email
> next dev

  ▲ Next.js 14.2.3
  - Local:        http://localhost:3000

 ✓ Starting...
 ✓ Ready in 1663ms
 ○ Compiling / ...
 ⨯ ./app/page.js:2:1
Module not found: Can't resolve '@/components/Subscribers'
```
```js
  1 | import { SubscriptionForm } from "@/components/subscription-form";
> 2 | import { Subscribers } from "@/components/Subscribers";
    | ^
  3 |
  4 | export default function Home() {
  5 |   return (
```